### PR TITLE
update_all.sh: fail if one of updatesrc_update fails

### DIFF
--- a/scripts/update_all.sh
+++ b/scripts/update_all.sh
@@ -3,7 +3,7 @@
 # This script will query for all of the updatesrc_update targets and execute
 # each one.
 
-set -uo pipefail
+set -euo pipefail
 
 cd "${BUILD_WORKSPACE_DIRECTORY}"
 


### PR DESCRIPTION
Currently the `update_all.sh` script does not fail if a `bazel run`
against a single target fails. Adding `set -e` should fix that.